### PR TITLE
Update the path to the modules.

### DIFF
--- a/display.go
+++ b/display.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"time"
 
-	"code.google.com/p/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/client"
 	"github.com/tarm/goserial"
 )
 

--- a/main/display.go
+++ b/main/display.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 
-	"code.google.com/p/certificate-transparency.schwag"
-	"code.google.com/p/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/client"
+	"github.com/google/ct-hackday-schwag"
 )
 
 var logUri = flag.String("log_uri", "http://ct.googleapis.com/pilot", "CT Log base URI")


### PR DESCRIPTION
This allows it to build, but there will be a similar commit needed in github.com/google/certificate-transparency/go/client, I suspect (which will be forthcoming).
