### PR TITLE
Re-layout so the installed binary has a better name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ Import into your Go workspace like this:
 
     go get github.com/google/ct-hackday-schwag
 
-To compile it, run the following command from the top of your Go
-workspace:
-
-    go build src/github.com/google/ct-hackday-schwag/main/display.go
+This will download, build, and install the binary.
 
 ## Contributing
 

--- a/internal/display.go
+++ b/internal/display.go
@@ -4,7 +4,7 @@
 // This package can be used to drive any serially connected LCD which is
 // compatible with the Matrix Orbital command set, although currently
 // the code assumes an 16x2 LCD.
-package schwag
+package internal
 
 import (
 	"flag"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 
 	"github.com/google/certificate-transparency/go/client"
-	"github.com/google/ct-hackday-schwag"
+	"github.com/google/ct-hackday-schwag/internal"
 )
 
 var logUri = flag.String("log_uri", "http://ct.googleapis.com/pilot", "CT Log base URI")
@@ -18,7 +18,7 @@ var staleAge = flag.Int("stale_age", 90*60, "STH age in seconds after which the 
 func main() {
 	flag.Parse()
 	logClient := client.New(*logUri)
-	displayConfig := schwag.DisplayConfig{
+	displayConfig := internal.DisplayConfig{
 		Client:    logClient,
 		Name:      *logName,
 		Port:      *serialDevice,
@@ -27,7 +27,7 @@ func main() {
 		StaleAge:  *staleAge,
 		FetchSecs: *fetchSecs,
 	}
-	display, err := schwag.NewLCDDisplay(displayConfig)
+	display, err := internal.NewLCDDisplay(displayConfig)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
Did a bit of digging around on how Go binaries and packages are usually done, and this seems to be fairly idiomatic (at least in usage, the "internal" sub-package could be differently named). With this pull request merged in, `go get github.com/google/ct-hackday-schwag` will get you a `ct-hackday-schwag` binary installed somewhere in a `bin` of your $GOPATH.
